### PR TITLE
Allow newrelic_rpm < 8.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2021-05-17
+- Require newrelic_rpm > 6 and < 8
+
 ## [1.1.0] - 2020-08-27
 ### Added
 - Record response status on external request span

--- a/lib/newrelic/manticore/version.rb
+++ b/lib/newrelic/manticore/version.rb
@@ -2,6 +2,6 @@
 
 module Newrelic
   module Manticore
-    VERSION = "1.1.0"
+    VERSION = "1.2.0"
   end
 end

--- a/newrelic-manticore.gemspec
+++ b/newrelic-manticore.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_runtime_dependency     "manticore", "~> 0.6", ">= 0.6.4"
-  gem.add_runtime_dependency     "newrelic_rpm", "~> 6"
+  gem.add_runtime_dependency     "newrelic_rpm", ">= 6", "< 8"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "faraday", "~> 0"


### PR DESCRIPTION
We cannot update newrelic_rpm to the latest version (v7.0) because it is locked in this gem to v6.